### PR TITLE
Adding missing pending annotation

### DIFF
--- a/src/test/java/starter/math/WhenAddingNumbers.java
+++ b/src/test/java/starter/math/WhenAddingNumbers.java
@@ -16,6 +16,7 @@ public class WhenAddingNumbers {
     MathWizSteps michael;
 
     @Test
+    @Pending
     public void addingSums() {
         // Given
         michael.startsWith(1);


### PR DESCRIPTION
According to the serenity book, the first test run should be pending not passing.