### PR TITLE
Update build.gradle to add a missing comma before the assertj dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ dependencies {
 
     testCompile "net.serenity-bdd:serenity-core:${serenityCoreVersion}",
                 "net.serenity-bdd:serenity-junit:${serenityCoreVersion}",
-                "junit:junit:${junitVersion}"
+                "junit:junit:${junitVersion}",
                 "org.assertj:assertj-core:${assertJVersion}"
 }
 


### PR DESCRIPTION
Hello,

I found that I needed to add a missing comma in the test compile dependencies in order for Gradle to pick up the assertj-core dependency.