### PR TITLE
add missing logbackVersion to build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,7 @@ ext {
     junitVersion = '5.8.2'
     assertJVersion = '3.23.1'
     lombokVersion = '1.18.24'
+    logbackVersion = '1.4.4'
 }
 
 dependencies {


### PR DESCRIPTION
logback dependency version is missing for gradle, but works for maven

Fixes error when running `./gradlew test` seen below

FAILURE: Build failed with an exception.

* Where: Build file '......serenity-junit-starter\build.gradle' line: 37

* What went wrong: A problem occurred evaluating root project 'serenity-junit-starter'.
> Could not get unknown property 'logbackVersion' for object of type org.gradle.api.internal.artifacts.dsl.dependencies.DefaultDependencyHandler.